### PR TITLE
008 - Refactor cognitive complexity for switch statements

### DIFF
--- a/src/main/ui/AnalysisMetricsDialog.java
+++ b/src/main/ui/AnalysisMetricsDialog.java
@@ -599,6 +599,9 @@ public class AnalysisMetricsDialog extends TitleAreaDialog {
         tableContainer.setLayout(new GridLayout(1, false));
         GridData tcGD = new GridData(SWT.FILL, SWT.FILL, true, false);
         tcGD.heightHint = 180; // make table section smaller; content still scrollable, unlimited rows
+        if(actionType == ActionType.CLASS) {
+        	tcGD.heightHint = 140;
+        }
         tableContainer.setLayoutData(tcGD);
         int style = SWT.BORDER | SWT.FULL_SELECTION | SWT.V_SCROLL | SWT.H_SCROLL;
         Table table = new Table(tableContainer, style);


### PR DESCRIPTION
Switch statements now contribute a single point to base cognitive complexity, regardless of the number of cases. SwitchCase nodes no longer add inherent complexity. Also, adjusted table height for class action type in AnalysisMetricsDialog.