### PR TITLE
011.5 - Fix CPLEX path handling and update UI hints

### DIFF
--- a/src/main/preferences/PluginPreferences.java
+++ b/src/main/preferences/PluginPreferences.java
@@ -99,7 +99,7 @@ public final class PluginPreferences {
         path = path.trim();
         
         try {
-        	System.load(path + "libcplex2212.dylib");
+        	System.load(path + "/libcplex2212.dylib");
             
             cplexLoaded = true;
             System.out.println(">> CPLEX: Librería cargada correctamente desde: " + path);

--- a/src/main/ui/ConfigurationDialog.java
+++ b/src/main/ui/ConfigurationDialog.java
@@ -93,23 +93,13 @@ public class ConfigurationDialog extends TitleAreaDialog {
 
         Label ilpHint = new Label(content, SWT.WRAP);
         String ilpHintText = isEnglish 
-            ? "Example: /Applications/CPLEX_Studio/cplex/bin/x86-64_osx/"
-            : "Ejemplo: /Applications/CPLEX_Studio/cplex/bin/x86-64_osx/";
+            ? "Example: /Applications/CPLEX_Studio/cplex/bin/x86-64_osx"
+            : "Ejemplo: /Applications/CPLEX_Studio/cplex/bin/x86-64_osx";
         ilpHint.setText(ilpHintText);
         ilpHint.setForeground(content.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
         GridData ilpHintGD = new GridData(SWT.FILL, SWT.CENTER, true, false);
         ilpHintGD.horizontalSpan = 3;
         ilpHint.setLayoutData(ilpHintGD);
-        
-        Label ilpNote = new Label(content, SWT.WRAP);
-        String ilpNoteText = isEnglish 
-            ? "Note: The path must end with \"/\""
-            : "Nota: El path debe terminar con \"/\"";
-        ilpNote.setText(ilpNoteText);
-        ilpNote.setForeground(content.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
-        GridData ilpNoteGD = new GridData(SWT.FILL, SWT.CENTER, true, false);
-        ilpNoteGD.horizontalSpan = 3;
-        ilpNote.setLayoutData(ilpNoteGD);
         
         Label ilpStatus = new Label(content, SWT.NONE);
         String statusText = PluginPreferences.isCplexLoaded() 


### PR DESCRIPTION
Added missing slash in System.load path for CPLEX library in PluginPreferences. Updated ConfigurationDialog to remove the requirement and note that the path must end with a slash, and adjusted example hints accordingly.