### PR TITLE
011.5.1 - Load CPLEX on startup and notify user

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -106,4 +106,9 @@
       </page>
    </extension>
 
+   <!-- Startup extension para cargar CPLEX cuando el workbench esté listo -->
+   <extension point="org.eclipse.ui.startup">
+      <startup class="main.boot.Activator"/>
+   </extension>
+
 </plugin>

--- a/src/main/boot/Activator.java
+++ b/src/main/boot/Activator.java
@@ -1,12 +1,18 @@
 package main.boot;
 
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IStartup;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 import main.preferences.PluginPreferences;
 import main.session.SessionAnalysisStore;
 
-public class Activator extends AbstractUIPlugin {
+public class Activator extends AbstractUIPlugin implements IStartup {
 
     public static final String PLUGIN_ID = "Refactorer"; 
 
@@ -21,10 +27,80 @@ public class Activator extends AbstractUIPlugin {
         super.start(context);
         plugin = this;
         
-        PluginPreferences.loadCplexLibrary();
-        
         SessionAnalysisStore.getInstance().clear();
         System.out.println(">> Plugin Refactorer ACTIVADO correctamente");
+    }
+    
+    /**
+     * Se ejecuta cuando el workbench está completamente cargado.
+     * Aquí cargamos CPLEX porque las preferencias ya están disponibles.
+     */
+    @Override
+    public void earlyStartup() {
+        System.out.println(">> Activator.earlyStartup() - Workbench listo");
+        loadCplexWithNotification();
+    }
+    
+    /**
+     * Carga la librería CPLEX si está configurada y muestra una notificación al usuario.
+     */
+    private void loadCplexWithNotification() {
+        String configuredPath = PluginPreferences.getIlpExecutablePath();
+        
+        if (configuredPath == null || configuredPath.trim().isEmpty()) {
+            System.out.println(">> CPLEX: No hay ruta configurada, omitiendo carga");
+            return;
+        }
+        
+        System.out.println(">> CPLEX: Intentando cargar desde ruta almacenada: " + configuredPath);
+        boolean loaded = PluginPreferences.loadCplexFromPath(configuredPath.trim());
+        
+        if (loaded) {
+            showCplexLoadedNotification();
+        } else {
+            System.out.println(">> CPLEX: No se pudo cargar la librería");
+        }
+    }
+    
+    /**
+     * Muestra una notificación visual al usuario indicando que CPLEX fue cargado.
+     * Se ejecuta de forma asíncrona para garantizar que la UI esté disponible.
+     */
+    private void showCplexLoadedNotification() {
+        Display display = Display.getDefault();
+        if (display == null) {
+            System.out.println(">> CPLEX: Display no disponible, omitiendo notificación visual");
+            return;
+        }
+        
+        display.asyncExec(() -> {
+            try {
+                IWorkbench workbench = PlatformUI.getWorkbench();
+                if (workbench == null) {
+                    return;
+                }
+                
+                IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+                if (window == null) {
+                    IWorkbenchWindow[] windows = workbench.getWorkbenchWindows();
+                    if (windows.length > 0) {
+                        window = windows[0];
+                    }
+                }
+                
+                if (window != null && window.getShell() != null) {
+                    boolean isEnglish = PluginPreferences.isEnglish();
+                    String title = isEnglish ? "CPLEX Loaded" : "CPLEX Cargado";
+                    String message = isEnglish 
+                        ? "CPLEX library loaded successfully on plugin startup. ILP algorithm is now available."
+                        : "Librería CPLEX cargada correctamente al iniciar el plugin. El algoritmo ILP está disponible.";
+                    
+                    MessageDialog.openInformation(window.getShell(), title, message);
+                }
+            } catch (Exception e) {
+                System.err.println(">> CPLEX: Error mostrando notificación: " + e.getMessage());
+            }
+        });
     }
 
     @Override

--- a/src/main/preferences/PluginPreferences.java
+++ b/src/main/preferences/PluginPreferences.java
@@ -105,6 +105,13 @@ public final class PluginPreferences {
             System.out.println(">> CPLEX: Librería cargada correctamente desde: " + path);
             return true;
         } catch (UnsatisfiedLinkError e) {
+            String message = e.getMessage();
+            // Si el error indica que la librería ya está cargada, consideramos éxito
+            if (message != null && (message.contains("already loaded") || message.contains("Native Library"))) {
+                cplexLoaded = true;
+                System.out.println(">> CPLEX: Librería ya estaba cargada en la JVM: " + path);
+                return true;
+            }
         	cplexLoaded = false;
             System.err.println(">> CPLEX: Error al cargar la librería: " + e.getMessage());
             return false;


### PR DESCRIPTION
Add startup extension and change Activator to implement IStartup so CPLEX is loaded after the workbench is ready (preferences are available). plugin.xml registers main.boot.Activator as an org.eclipse.ui.startup extension. Activator now performs earlyStartup(), attempts to load CPLEX from the configured path via PluginPreferences, and shows an asynchronous information dialog (localized) when loading succeeds; logs and safety checks added for missing path, display availability, and load failures. Also removed the previous immediate load from start(). PluginPreferences was updated to treat UnsatisfiedLinkError messages that indicate the native library is already loaded as a successful load to avoid false negatives.