### PR TITLE
015 - Fix ESH execution

### DIFF
--- a/src/main/neo/core/refactoringcache/ConsecutiveSequenceIterator.java
+++ b/src/main/neo/core/refactoringcache/ConsecutiveSequenceIterator.java
@@ -131,21 +131,20 @@ public class ConsecutiveSequenceIterator {
 
 		// Iterate through potential start points that have complexity
 		for (int i = first; i <= lastWithCC; i++) {
-			int startIndex;
-			int endIndex;
+			// A sequence starting at sentence {@code i} must end somewhere within the
+			// inclusive range [nextWithCC[i], last] so it captures at least one
+			// complexity-contributing statement. The chosen Approach only changes the
+			// order in which that range is explored, never the range itself.
+			int shortestEnd = nextWithCC[i];
+			int longestEnd = last;
 
-			// Determine loop bounds based on the chosen Approach
-			if (approach.equals(Approach.LONG_SEQUENCE_FIRST)) {
-				// Try longest possible sequences first
-				startIndex = last;
-				endIndex = nextWithCC[i];
-			} else {
-				// Try shortest sequences first (expanding outwards)
-				startIndex = nextWithCC[i];
-				endIndex = last;
-			}
+			// LONG_SEQUENCE_FIRST walks the range from the longest sequence (j = last)
+			// down to the shortest; SHORT_SEQUENCE_FIRST walks it the other way around.
+			boolean longSequenceFirst = approach.equals(Approach.LONG_SEQUENCE_FIRST);
+			int startIndex = longSequenceFirst ? longestEnd : shortestEnd;
+			int step = longSequenceFirst ? -1 : 1;
 
-			for (int j = startIndex; j <= endIndex; j++) {
+			for (int j = startIndex; j >= shortestEnd && j <= longestEnd; j += step) {
 				if (sequence.validSequence(i, j)) {
 					los.push(i);
 					los.push(j);

--- a/src/main/neo/core/refactoringcache/mase/patterns/yieldreturn/IteratorYield.java
+++ b/src/main/neo/core/refactoringcache/mase/patterns/yieldreturn/IteratorYield.java
@@ -81,7 +81,10 @@ public class IteratorYield<T> implements Iterator<T>
 				{
 					if (th != null)
 					{
-						th.stop();
+						// The worker thread is parked in Break()'s wait(); interrupt it so it
+						// unwinds and terminates. Thread.stop() must not be used: it throws
+						// UnsupportedOperationException as of Java 20+.
+						th.interrupt();
 					}
 					th=null;
 					throw new NoSuchElementException();
@@ -121,6 +124,7 @@ public class IteratorYield<T> implements Iterator<T>
 					
 				}
 			};
+			th.setDaemon(true);
 			th.start();
 		}
 		yi.notify();
@@ -149,7 +153,10 @@ public class IteratorYield<T> implements Iterator<T>
 				{
 					if (th != null)
 					{
-						th.stop();
+						// The worker thread is parked in Break()'s wait(); interrupt it so it
+						// unwinds and terminates. Thread.stop() must not be used: it throws
+						// UnsupportedOperationException as of Java 20+.
+						th.interrupt();
 					}
 					th=null;
 					return false;

--- a/src/main/refactor/CodeExtractionEngine.java
+++ b/src/main/refactor/CodeExtractionEngine.java
@@ -71,16 +71,16 @@ public final class CodeExtractionEngine {
 
 		Solution solution;
 		boolean usedILP;
-		try {
-			SolverContext ctx = new SolverContext(cu, record, SolverType.ILP.getKey(), threshold);
-			GraphBundle graphs = GraphService.buildGraphs(cache, node);
-			ctx.setPrecomputedGraphs(graphs);
+		SolverContext ctx = new SolverContext(cu, record, SolverType.ILP.getKey(), threshold);
+		GraphBundle graphs = GraphService.buildGraphs(cache, node);
+		ctx.setPrecomputedGraphs(graphs);
 
-			solution = runSolver(ctx, cache);
-			usedILP = solution != null;
-		} catch(Exception e) {
+		solution = runSolver(ctx, cache);
+		usedILP = solution != null;
+		
+		if(solution == null) {
 			// Fallback to enumerative search if CPLEX is unavailable or failed.
-			SolverContext ctx = new SolverContext(cu, record, SolverType.ES_LONG_SEQUENCE_FIRST.getKey(), threshold);
+			ctx = new SolverContext(cu, record, SolverType.ES_LONG_SEQUENCE_FIRST.getKey(), threshold);
 			solution = runFallback(ctx, cache);
 			usedILP = false;
 		}


### PR DESCRIPTION
Consolidate and clarify iteration logic, replace unsafe thread stops, and simplify solver fallback.

- ConsecutiveSequenceIterator: Compute the inclusive end-range once (shortestEnd..longestEnd) and drive the inner loop with a start/step pair depending on Approach. Adds comments to explain the invariant and traversal order.
- IteratorYield: Replace deprecated/unsafe Thread.stop() calls with Thread.interrupt() so the worker thread can unwind from its parked wait; mark the worker thread as a daemon and add explanatory comments. This makes thread termination safe on modern JVMs (Java 20+).
- CodeExtractionEngine: Remove the surrounding try/catch, run the ILP solver first and only construct a fallback SolverContext when the solution is null, simplifying control flow and ensuring the fallback path is clear.

These changes improve readability, safety (thread lifecycle), and fallback behavior without altering the intended algorithms.